### PR TITLE
해시태그 기능 개선

### DIFF
--- a/normalBoard/src/main/java/com/example/normalboard/controller/ArticleController.java
+++ b/normalBoard/src/main/java/com/example/normalboard/controller/ArticleController.java
@@ -50,6 +50,8 @@ public class ArticleController {
         model.addAttribute("articles",articleResponse.map(ArticleResponse :: from));
         model.addAttribute("searchTypes",SearchType.values());
         model.addAttribute("paginationBarNumbers",barNumber);
+        model.addAttribute("searchTypeHashtag",SearchType.HASHTAG);
+
         return "/articles/index";
     }
 
@@ -60,6 +62,7 @@ public class ArticleController {
         model.addAttribute("article",article);
         model.addAttribute("articleComments",article.getArticleCommentResponses());
         model.addAttribute("totalCount", articleService.getArticleCount());
+        model.addAttribute("searchTypeHashtag",SearchType.HASHTAG);
         return "/articles/detail";
     }
 

--- a/normalBoard/src/main/java/com/example/normalboard/domain/Hashtag.java
+++ b/normalBoard/src/main/java/com/example/normalboard/domain/Hashtag.java
@@ -44,7 +44,7 @@ public class Hashtag extends BaseEntity{
         if (this == o) return true;
         if (!(o instanceof Hashtag)) return false;
         Hashtag that = (Hashtag) o;
-        return Objects.equals(this.getId(), that.getId());
+        return this.getId() != null && Objects.equals(this.getId(), that.getId());
     }
 
     @Override

--- a/normalBoard/src/main/java/com/example/normalboard/repository/HashtagRepository.java
+++ b/normalBoard/src/main/java/com/example/normalboard/repository/HashtagRepository.java
@@ -16,6 +16,8 @@ public interface HashtagRepository extends
         JpaRepository<Hashtag, Long>,
         HashtagRepositoryCustom,
         QuerydslPredicateExecutor<Hashtag> {
+
     Optional<Hashtag> findByHashtagName(String hashtagName);
+
     List<Hashtag> findByHashtagNameIn(Set<String> hashtagNames);
 }

--- a/normalBoard/src/main/java/com/example/normalboard/service/ArticleService.java
+++ b/normalBoard/src/main/java/com/example/normalboard/service/ArticleService.java
@@ -1,11 +1,13 @@
 package com.example.normalboard.service;
 
 import com.example.normalboard.domain.Article;
+import com.example.normalboard.domain.Hashtag;
 import com.example.normalboard.domain.UserAccount;
 import com.example.normalboard.domain.constant.SearchType;
 import com.example.normalboard.dto.ArticleDto;
 import com.example.normalboard.dto.ArticleWithCommentsDto;
 import com.example.normalboard.repository.ArticleRepository;
+import com.example.normalboard.repository.HashtagRepository;
 import com.example.normalboard.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,10 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.*;
@@ -32,6 +31,8 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
     private final UserAccountRepository userAccountRepository;
+    private final HashtagService hashtagService;
+    private final HashtagRepository hashtagRepository;
 
     @Transactional(readOnly = true)
     public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
@@ -89,7 +90,34 @@ public class ArticleService {
 
     public void saveArticle(ArticleDto dto) {
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.getUserAccountDto().getUserId());
-        articleRepository.save(dto.toEntity(userAccount));
+
+        Set<Hashtag> hashtags = renewHashtagsFrom(dto.getContent());
+
+        Article article = dto.toEntity(userAccount);
+
+        article.addHashtags(hashtags);
+
+        articleRepository.save(article);
+    }
+
+    private Set<Hashtag> renewHashtagsFrom(String content) {
+
+        Set<String> hashtagNamesInContent = hashtagService.parseHashtagNames(content);
+
+        Set<Hashtag> hashtags = hashtagService.findHashtagsByNames(hashtagNamesInContent);
+
+        Set<String> existingHashtagNames = hashtags
+                .stream()
+                .map(Hashtag::getHashtagName)
+                .collect(toSet());
+
+        hashtags.addAll(hashtagNamesInContent
+                .stream()
+                .filter(ele->!existingHashtagNames.contains(ele))
+                .map(Hashtag::of)
+                .collect(toList()));
+
+        return hashtags;
     }
 
     public void updateArticle(Long articleId,ArticleDto dto) {
@@ -99,17 +127,40 @@ public class ArticleService {
             log.warn("수정할 게시글이 없습니다.");
         }
     }
+
     private void tryToUpdateArticle(Long articleId,ArticleDto dto){
         Article article = articleRepository.getReferenceById(articleId);
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.getUserAccountDto().getUserId());
-        if(article.getUserAccount().equals(userAccount))
+        if(article.getUserAccount().equals(userAccount)){
+
             article.updateContent(dto.getTitle(),dto.getContent());
+
+            Set<Long> hashtagIds = article.getHashtags()
+                    .stream().map(Hashtag::getId)
+                    .collect(toUnmodifiableSet());
+
+            article.clearHashtag();
+
+            articleRepository.flush();
+
+            hashtagService.deleteAllHashtagWithoutArticles(hashtagIds);
+
+            article.addHashtags(renewHashtagsFrom(dto.getContent()));
+        }
 
     }
 
-    public void deleteArticle(Long id , String userId) {
+    public void deleteArticle(Long articleId , String userId) {
+        Article article = articleRepository.getReferenceById(articleId);
 
-        articleRepository.deleteByIdAndUserAccount_UserId(id,userId);
+        Set<Long> hashtagIds = article.getHashtags()
+                .stream().map(Hashtag::getId)
+                .collect(toUnmodifiableSet());
+
+        articleRepository.deleteByIdAndUserAccount_UserId(articleId,userId);
+        articleRepository.flush();
+
+        hashtagService.deleteAllHashtagWithoutArticles(hashtagIds);
     }
 
     public long getArticleCount() {
@@ -117,16 +168,16 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
-        if (hashtag == null || hashtag.isBlank()) {
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtagName, Pageable pageable) {
+
+        if (hashtagName == null || hashtagName.isBlank()) {
             return Page.empty(pageable);
         }
-        return articleRepository.findByHashtagNames(null, pageable).map(ArticleDto::from);
+        return articleRepository.findByHashtagNames(List.of(hashtagName), pageable).map(ArticleDto::from);
     }
 
 
     public List<String> getHashtags() {
-        return articleRepository
-                .findAllDistinctHashtags();
+        return hashtagRepository.findAllHashtagNames(); //TODO : 해시태그 서비스에 위임하는 것을 고려
     }
 }

--- a/normalBoard/src/main/java/com/example/normalboard/service/HashtagService.java
+++ b/normalBoard/src/main/java/com/example/normalboard/service/HashtagService.java
@@ -1,21 +1,59 @@
 package com.example.normalboard.service;
 
+import com.example.normalboard.domain.Hashtag;
+import com.example.normalboard.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
+@Transactional
 public class HashtagService {
 
-    public Object parseHashtagNames(String content) {
-        return null;
+    private final HashtagRepository hashtagRepository;
+
+    public Set<String> parseHashtagNames(String content) {
+        if(content == null) return Set.of();
+
+        Set<String> hashtagNames = new HashSet<>();
+
+        Matcher matcher = extractHashtagNameWithHashtagFrom(content);
+
+        while(matcher.find()) hashtagNames.add(removeHashtagAndReturnHashtagName(matcher));
+
+        return Set.copyOf(hashtagNames);
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    private Matcher extractHashtagNameWithHashtagFrom(String content){
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        return  pattern.matcher(content.strip());
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    private String removeHashtagAndReturnHashtagName(Matcher matcher){
+        return matcher.group().substring(1);
+    }
+
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
+    }
+
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if(hashtag.getArticles().isEmpty()) hashtagRepository.delete(hashtag);
+    }
+
+    public void deleteAllHashtagWithoutArticles(Set<Long> hashtags) {
+        for(var element : hashtags) deleteHashtagWithoutArticles(element);
     }
 
 }

--- a/normalBoard/src/main/resources/data.sql
+++ b/normalBoard/src/main/resources/data.sql
@@ -677,6 +677,7 @@ insert into hashtag (hashtag_name, created_at, modified_at, created_by, modified
                                                                                          ('violet', now(), now(), 'uno', 'uno'),
                                                                                          ('yellow', now(), now(), 'uno', 'uno'),
                                                                                          ('white', now(), now(), 'uno', 'uno')
+
 ;
 
 insert into article_hashtag (article_id, hashtag_id) values

--- a/normalBoard/src/main/resources/templates/articles/detail.html
+++ b/normalBoard/src/main/resources/templates/articles/detail.html
@@ -2,8 +2,12 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
     <title>게시글 페이지</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link href="/css/articles/article-content.css" rel="stylesheet">
 </head>
 
@@ -13,6 +17,7 @@
     헤더 삽입부
     <hr>
 </header>
+
 <main id="article-main" class="container">
     <header id="article-header" class="py-5 text-center">
         <h1>첫번째 글</h1>
@@ -24,7 +29,7 @@
                 <p><span id="nickname">Uno</span></p>
                 <p><a id="email" href="mailto:djkehh@gmail.com">uno@mail.com</a></p>
                 <p><time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time></p>
-                <p><span id="hashtag">#java</span></p>
+                <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
             </aside>
         </section>
 
@@ -91,6 +96,7 @@
                     </div>
                 </li>
             </ul>
+
         </section>
     </div>
 
@@ -110,12 +116,13 @@
             </ul>
         </nav>
     </div>
-
 </main>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+
 <footer id="footer">
     <hr>
     푸터 삽입부
 </footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/normalBoard/src/main/resources/templates/articles/detail.th.xml
+++ b/normalBoard/src/main/resources/templates/articles/detail.th.xml
@@ -8,7 +8,13 @@
         <attr sel="#nickname" th:text="*{nickname}" />
         <attr sel="#email" th:text="*{email}" />
         <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-        <attr sel="#hashtag" th:text="*{hashtag}" />
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
+        </attr>
+
         <attr sel="#article-content/pre" th:text="*{content}" />
 
         <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
@@ -16,7 +22,6 @@
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
         </attr>
-
 
         <attr sel=".article-id" th:name="articleId" th:value="*{id}" />
         <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
@@ -33,7 +38,6 @@
                 </attr>
             </attr>
         </attr>
-
 
         <attr sel="#pagination">
             <attr sel="ul">

--- a/normalBoard/src/main/resources/templates/articles/form.html
+++ b/normalBoard/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
                 <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
             </div>
         </div>
-        <div class="row mb-4 justify-content-md-center">
-            <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-            <div class="col-sm-8 col-lg-9">
-                <input type="text" class="form-control" id="hashtag" name="hashtag">
-            </div>
-        </div>
         <div class="row mb-5 justify-content-md-center">
             <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
                 <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/normalBoard/src/main/resources/templates/articles/form.th.xml
+++ b/normalBoard/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/normalBoard/src/main/resources/templates/articles/index.html
+++ b/normalBoard/src/main/resources/templates/articles/index.html
@@ -2,21 +2,24 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>게시판 페이지</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
+    <title>게시판 페이지</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link href="/css/search-bar.css" rel="stylesheet">
     <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
 
 <body>
-
 <header id="header">
     헤더 삽입부
     <hr>
 </header>
 
 <main class="container">
+
     <div class="row">
         <div class="card card-margin search-form">
             <div class="card-body p-0">
@@ -65,29 +68,27 @@
             </tr>
             </thead>
             <tbody>
-        <tr>
-            <td class="title"><a>첫글</a></td>
-            <td class="hashtag">#java</td>
-            <td class="user-id">Uno</td>
-            <td class="created-at"><time>2022-01-01</time></td>
-        </tr>
-        <tr>
-            <td>두번째글</td>
-            <td>#spring</td>
-            <td>Uno</td>
-            <td><time>2022-01-02</time></td>
-        </tr>
-        <tr>
-            <td>세번째글</td>
-            <td>#java</td>
-            <td>Uno</td>
-            <td><time>2022-01-03</time></td>
-        </tr>
+            <tr>
+                <td class="title"><a>첫글</a></td>
+                <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
+                <td class="user-id">Uno</td>
+                <td class="created-at"><time>2022-01-01</time></td>
+            </tr>
+            <tr>
+                <td>두번째글</td>
+                <td>#spring</td>
+                <td>Uno</td>
+                <td><time>2022-01-02</time></td>
+            </tr>
+            <tr>
+                <td>세번째글</td>
+                <td>#java</td>
+                <td>Uno</td>
+                <td><time>2022-01-03</time></td>
+            </tr>
             </tbody>
         </table>
     </div>
-
-
 
     <div class="row">
         <div class="d-grid gap-2 d-md-flex justify-content-md-end">
@@ -104,13 +105,13 @@
             </ul>
         </nav>
     </div>
-
 </main>
 
 <footer id="footer">
     <hr>
     푸터 삽입부
 </footer>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/normalBoard/src/main/resources/templates/articles/index.th.xml
+++ b/normalBoard/src/main/resources/templates/articles/index.th.xml
@@ -2,6 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header" />
     <attr sel="#footer" th:replace="footer :: footer" />
+
     <attr sel="main" th:object="${articles}">
         <attr sel="#search-form" th:action="@{/articles}" th:method="get" />
         <attr sel="#search-type" th:remove="all-but-first">
@@ -24,7 +25,7 @@
         )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
             page=${articles.number},
-            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
             searchType=${param.searchType},
             searchValue=${param.searchValue}
         )}"/>
@@ -42,15 +43,21 @@
         )}"/>
             </attr>
 
-        <attr sel="tbody" th:remove="all-but-first">
-            <attr sel="tr[0]" th:each="article : ${articles}">
-                <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                <attr sel="td.hashtag" th:text="${article.hashtag}" />
-                <attr sel="td.user-id" th:text="${article.nickname}" />
-                <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                        <attr sel="a"
+                              th:text="'#' + ${hashtag}"
+                              th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+                        />
+                    </attr>
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
             </attr>
         </attr>
-    </attr>
+
         <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">

--- a/normalBoard/src/test/java/com/example/normalboard/service/ArticleServiceTest.java
+++ b/normalBoard/src/test/java/com/example/normalboard/service/ArticleServiceTest.java
@@ -241,7 +241,7 @@ class ArticleServiceTest {
         given(articleRepository.getReferenceById(dto.getId())).willReturn(article);
         given(userAccountRepository.getReferenceById(dto.getUserAccountDto().getUserId())).willReturn(dto.getUserAccountDto().toEntity());
         willDoNothing().given(articleRepository).flush();
-        willDoNothing().given(hashtagService).deleteHashtagWithoutArticles(any());
+        willDoNothing().given(hashtagService).deleteAllHashtagWithoutArticles(any());
         given(hashtagService.parseHashtagNames(dto.getContent())).willReturn(expectedHashtagNames);
         given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedHashtags);
 
@@ -259,7 +259,7 @@ class ArticleServiceTest {
         then(articleRepository).should().getReferenceById(dto.getId());
         then(userAccountRepository).should().getReferenceById(dto.getUserAccountDto().getUserId());
         then(articleRepository).should().flush();
-        then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
+        then(hashtagService).should().deleteAllHashtagWithoutArticles(any());
         then(hashtagService).should().parseHashtagNames(dto.getContent());
         then(hashtagService).should().findHashtagsByNames(expectedHashtagNames);
 
@@ -310,7 +310,7 @@ class ArticleServiceTest {
         given(articleRepository.getReferenceById(articleId)).willReturn(createArticle());
         willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
         willDoNothing().given(articleRepository).flush();
-        willDoNothing().given(hashtagService).deleteHashtagWithoutArticles(any());
+        willDoNothing().given(hashtagService).deleteAllHashtagWithoutArticles(any());
 
         // When
         sut.deleteArticle(1L, userId);
@@ -319,7 +319,7 @@ class ArticleServiceTest {
         then(articleRepository).should().getReferenceById(articleId);
         then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
         then(articleRepository).should().flush();
-        then(hashtagService).should(times(2)).deleteHashtagWithoutArticles(any());
+        then(hashtagService).should().deleteAllHashtagWithoutArticles(any());
     }
 
     @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다.")

--- a/normalBoard/src/test/java/com/example/normalboard/service/HashtagServiceTest.java
+++ b/normalBoard/src/test/java/com/example/normalboard/service/HashtagServiceTest.java
@@ -1,0 +1,88 @@
+package com.example.normalboard.service;
+
+import com.example.normalboard.domain.Hashtag;
+import com.example.normalboard.repository.HashtagRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비지니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks private HashtagService sut;
+
+    @Mock private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문안에 해시태그를 중복 없이 추출")
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    @MethodSource(value = "givenContent_whenParsing_thenReturnUniqueHashTagNames")
+    public void givenContent_whenParsing_thenReturnUniqueHashTagNames(String content,Set<String> expected) throws Exception{
+        // given
+        // when
+        Set<String> actual = sut.parseHashtagNames(content);
+        // then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnUniqueHashTagNames(){
+        return Stream.of(
+                arguments("#java",Set.of("java")),
+                arguments("#java#java",Set.of("java")),
+                arguments("#java#spring",Set.of("java","spring")),
+                arguments("#  ",Set.of()),
+                arguments("  #  ",Set.of()),
+                arguments("   #",Set.of()),
+                arguments(null,Set.of()),
+                arguments("null",Set.of()),
+                arguments("javajavasa;lvdsfewfmdsadhk##das",Set.of("das")),
+                arguments("#_java_spring_##das",Set.of("_java_spring_","das")),
+                arguments("#_java-spring##das",Set.of("_java","das")),
+                arguments("#java_spring",Set.of("java_spring"))
+        );
+    }
+
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("spring"),
+                Hashtag.of("java")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        System.out.println(hashtags);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+
+
+}


### PR DESCRIPTION
-  하나의 글이 여러 개의 해시태그를 저장할 수 있도록 만들기
-  별도의 입력 공간을 주지 않고 본문에서 해시태그를 파싱해서 기록하기
-  DB에는 #을 뺀 문자열을 저장하기
-  해시태그에 링크 삽입하기